### PR TITLE
Prevent multiple concurrent requests to refresh a withings access token

### DIFF
--- a/withingsslack/main.py
+++ b/withingsslack/main.py
@@ -137,6 +137,7 @@ def withings_notification_webhook(
         + f"userid={userid}, startdate={startdate}, enddate={enddate}"
     )
     if last_processed_notification_per_user.get(userid, None) != (startdate, enddate):
+        last_processed_notification_per_user[userid] = (startdate, enddate)
         try:
             last_weight_data = withings_api.get_last_weight(
                 db,
@@ -153,7 +154,6 @@ def withings_notification_webhook(
         else:
             if last_weight_data:
                 slack.post_weight(last_weight_data)
-                last_processed_notification_per_user[userid] = (startdate, enddate)
     else:
         logging.info("Ignoring duplicate withings notification")
     return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Perhaps we're getting logged out due to withings double webhook calls: if the access token is expired, we may have been trying to refresh the token twice.